### PR TITLE
Matching lowercase extensions

### DIFF
--- a/src/playbacks/html5_video/html5_video.js
+++ b/src/playbacks/html5_video/html5_video.js
@@ -408,6 +408,7 @@ export default class HTML5Video extends Playback {
 
 HTML5Video._canPlay = function(type, mimeTypesByExtension, resourceUrl, mimeType) {
   var extension = (resourceUrl.split('?')[0].match(/.*\.(.*)$/) || [])[1]
+  extension = (extension || "").toLowerCase()
   var mimeTypes = mimeType || mimeTypesByExtension[extension] || []
   mimeTypes = (mimeTypes.constructor === Array) ? mimeTypes : [mimeTypes]
 


### PR DESCRIPTION
In case the URL contains a uppercase character, it'll help match the mediaType list (e.g. "MP4" vs "mp4)
